### PR TITLE
Provide fieldset as tokens for the notification center

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,11 @@
     },
     "require":{
         "php": ">=7.1",
+        "ext-json": "*",
         "contao/core-bundle": "^4.4",
         "composer/semver": "^1.0",
-        "jean85/pretty-package-versions": "^1.0"
+        "jean85/pretty-package-versions": "^1.0",
+        "menatwork/contao-multicolumnwizard-bundle": "^3.4"
     },
     "require-dev": {
          "contao/manager-plugin": "^2.0"

--- a/src/EventListener/FormFieldDcaListener.php
+++ b/src/EventListener/FormFieldDcaListener.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the inspiredminds/contao-fieldset-duplication package.
+ *
+ * (c) inspiredminds
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace InspiredMinds\ContaoFieldsetDuplication\EventListener;
+
+use Contao\Controller;
+use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+
+final class FormFieldDcaListener
+{
+    /** @var ContaoFrameworkInterface */
+    private $framework;
+
+    public function __construct(ContaoFrameworkInterface $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    public function templateOptions(): array
+    {
+        $adapter = $this->framework->getAdapter(Controller::class);
+
+        return $adapter->getTemplateGroup('nc_fieldset_duplication_');
+    }
+}

--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -63,7 +63,7 @@ class FormHookListener implements FrameworkAwareInterface
             // search for duplicates
             foreach (array_keys($request->request->all()) as $duplicateName) {
                 // check if already processed
-                if (\in_array($duplicateName, $processed)) {
+                if (\in_array($duplicateName, $processed, true)) {
                     continue;
                 }
 
@@ -94,7 +94,7 @@ class FormHookListener implements FrameworkAwareInterface
                                     // remove allow duplication class
                                     if ($this->fieldHelper->isFieldsetStart($clone)) {
                                         $clone->class = implode(' ', array_diff(explode(' ', $clone->class), ['allow-duplication']));
-                                        $clone->class .= ($clone->class ? ' ' : '') . 'duplicate-fieldset-'.$field->id.' duplicate';
+                                        $clone->class .= ($clone->class ? ' ' : '').'duplicate-fieldset-'.$field->id.' duplicate';
                                     }
 
                                     // set the id
@@ -148,7 +148,7 @@ class FormHookListener implements FrameworkAwareInterface
                 // search for the index position of the original stop field
                 if (null !== $stopId) {
                     $stopIdx = null;
-                    for ($i = 0; $i < count($fields); ++$i) {
+                    for ($i = 0; $i < \count($fields); ++$i) {
                         if ($fields[$i]->id === $stopId) {
                             $stopIdx = $i;
                             break;
@@ -191,7 +191,7 @@ class FormHookListener implements FrameworkAwareInterface
     public function onPrepareFormData(array &$submittedData, array $labels, array $fields, Form $form): void
     {
         $fieldsetGroups = $this->buildFieldsetGroups($fields);
-        $values         = $this->groupFieldsetValues($fieldsetGroups, $submittedData);
+        $values = $this->groupFieldsetValues($fieldsetGroups, $submittedData);
 
         // Disable debug mode so that no html comments are rendered in the templates
         $debugMode = Config::get('debugMode');
@@ -212,13 +212,13 @@ class FormHookListener implements FrameworkAwareInterface
                 $template->setData(
                     [
                         'labels' => $labels,
-                        'form'   => $form,
+                        'form' => $form,
                         'config' => $row['config'],
-                        'values' => $row['data']
+                        'values' => $row['data'],
                     ]
                 );
 
-                $submittedData[$row['config']->name . '_' . $format['format']] = $template->parse();
+                $submittedData[$row['config']->name.'_'.$format['format']] = $template->parse();
             }
         }
 
@@ -227,10 +227,8 @@ class FormHookListener implements FrameworkAwareInterface
 
     /**
      * @param array|Widget[]|FormFieldModel[] $fields
-     *
-     * @return array
      */
-    private function buildFieldsetGroups(array $fields) : array
+    private function buildFieldsetGroups(array $fields): array
     {
         // field set groups
         $fieldsetGroups = [];
@@ -244,9 +242,9 @@ class FormHookListener implements FrameworkAwareInterface
             if ($this->fieldHelper->isFieldsetStart($field)) {
                 $fieldsetGroup[] = $field;
             } elseif ($this->fieldHelper->isFieldsetStop($field)) {
-                $fieldsetGroup[]                       = $field;
+                $fieldsetGroup[] = $field;
                 $fieldsetGroups[$fieldsetGroup[0]->id] = $fieldsetGroup;
-                $fieldsetGroup                         = [];
+                $fieldsetGroup = [];
             } elseif (!empty($fieldsetGroup)) {
                 $fieldsetGroup[] = $field;
             }
@@ -260,13 +258,13 @@ class FormHookListener implements FrameworkAwareInterface
         $data = [];
 
         foreach ($fieldsetGroups as $fieldsetId => $fieldsetGroup) {
-            $row            = [];
+            $row = [];
             $referenceGroup = $fieldsetGroup[0]->originalId > 0
                 ? $fieldsetGroups[$fieldsetGroup[0]->originalId]
                 : $fieldsetGroup;
 
             foreach ($fieldsetGroup as $formFieldIndex => $formFieldModel) {
-                if (array_key_exists($formFieldModel->name, $submittedData)) {
+                if (\array_key_exists($formFieldModel->name, $submittedData)) {
                     $row[$referenceGroup[$formFieldIndex]->name] = $submittedData[$formFieldModel->name];
                 }
             }

--- a/src/Helper/FieldHelper.php
+++ b/src/Helper/FieldHelper.php
@@ -36,7 +36,7 @@ class FieldHelper
 
     public function getFieldsetType($field): ?string
     {
-        if (!is_string($field->type) || false === strpos($field->type, 'fieldset')) {
+        if (!\is_string($field->type) || false === strpos($field->type, 'fieldset')) {
             return null;
         }
 

--- a/src/Helper/FieldHelper.php
+++ b/src/Helper/FieldHelper.php
@@ -36,7 +36,7 @@ class FieldHelper
 
     public function getFieldsetType($field): ?string
     {
-        if (false === strpos($field->type, 'fieldset')) {
+        if (!is_string($field->type) || false === strpos($field->type, 'fieldset')) {
             return null;
         }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -13,5 +13,9 @@ services:
       - '@request_stack'
       - '@inspiredminds.fieldsetduplication.helper.field'
 
+  InspiredMinds\ContaoFieldsetDuplication\EventListener\FormFieldDcaListener:
+    arguments:
+      - '@contao.framework'
+
   inspiredminds.fieldsetduplication.helper.field:
     class: InspiredMinds\ContaoFieldsetDuplication\Helper\FieldHelper

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-$GLOBALS['TL_HOOKS']['loadFormField'][] = ['inspiredminds.fieldsetduplication.listener.formhook', 'onLoadFormField'];
+$GLOBALS['TL_HOOKS']['loadFormField'][]     = ['inspiredminds.fieldsetduplication.listener.formhook', 'onLoadFormField'];
 $GLOBALS['TL_HOOKS']['compileFormFields'][] = ['inspiredminds.fieldsetduplication.listener.formhook', 'onCompileFormFields'];
+$GLOBALS['TL_HOOKS']['prepareFormData'][]   = ['inspiredminds.fieldsetduplication.listener.formhook', 'onPrepareFormData'];
 
 if (!\is_array($GLOBALS['TL_HOOKS']['storeFormData'])) {
     $GLOBALS['TL_HOOKS']['storeFormData'] = [];

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-$GLOBALS['TL_HOOKS']['loadFormField'][]     = ['inspiredminds.fieldsetduplication.listener.formhook', 'onLoadFormField'];
+$GLOBALS['TL_HOOKS']['loadFormField'][] = ['inspiredminds.fieldsetduplication.listener.formhook', 'onLoadFormField'];
 $GLOBALS['TL_HOOKS']['compileFormFields'][] = ['inspiredminds.fieldsetduplication.listener.formhook', 'onCompileFormFields'];
-$GLOBALS['TL_HOOKS']['prepareFormData'][]   = ['inspiredminds.fieldsetduplication.listener.formhook', 'onPrepareFormData'];
+$GLOBALS['TL_HOOKS']['prepareFormData'][] = ['inspiredminds.fieldsetduplication.listener.formhook', 'onPrepareFormData'];
 
 if (!\is_array($GLOBALS['TL_HOOKS']['storeFormData'])) {
     $GLOBALS['TL_HOOKS']['storeFormData'] = [];

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -26,27 +26,27 @@ $GLOBALS['TL_DCA']['tl_form_field']['fields']['allowDuplication'] = [
 ];
 
 $GLOBALS['TL_DCA']['tl_form_field']['fields']['notificationTokenTemplates'] = [
-    'label'            => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'],
-    'exclude'          => true,
-    'inputType'        => 'multiColumnWizard',
+    'label' => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'],
+    'exclude' => true,
+    'inputType' => 'multiColumnWizard',
     'options_callback' => [FormFieldDcaListener::class, 'templateOptions'],
-    'eval'             => [
-        'tl_class'     => 'clr',
+    'eval' => [
+        'tl_class' => 'clr',
         'columnFields' => [
-            'format'   => [
-                'label'     => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'],
+            'format' => [
+                'label' => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'],
                 'inputType' => 'text',
-                'eval'      => ['style' => 'width: 200px'],
+                'eval' => ['style' => 'width: 200px'],
             ],
             'template' => [
-                'label'            => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'],
-                'inputType'        => 'select',
+                'label' => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'],
+                'inputType' => 'select',
                 'options_callback' => [FormFieldDcaListener::class, 'templateOptions'],
-                'eval'             => ['includeBlankOption' => true, 'chosen' => true, 'style' => 'width:400px'],
+                'eval' => ['includeBlankOption' => true, 'chosen' => true, 'style' => 'width:400px'],
             ],
         ],
     ],
-    'sql'              => "blob NULL",
+    'sql' => 'blob NULL',
 ];
 
 $fieldsetPalette = System::getContainer()->get('inspiredminds.fieldsetduplication.helper.field')->getFieldsetPalette();

--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -12,13 +12,41 @@ declare(strict_types=1);
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\System;
+use InspiredMinds\ContaoFieldsetDuplication\EventListener\FormFieldDcaListener;
+
+$GLOBALS['TL_DCA']['tl_form_field']['palettes']['__selector__'][] = 'allowDuplication';
+$GLOBALS['TL_DCA']['tl_form_field']['subpalettes']['allowDuplication'] .= 'name,notificationTokenTemplates';
 
 $GLOBALS['TL_DCA']['tl_form_field']['fields']['allowDuplication'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_form_field']['allowDuplication'],
     'exclude' => true,
     'inputType' => 'checkbox',
-    'eval' => ['tl_class' => 'w50 m12'],
+    'eval' => ['tl_class' => 'w50 m12', 'submitOnChange' => true],
     'sql' => "char(1) NOT NULL default ''",
+];
+
+$GLOBALS['TL_DCA']['tl_form_field']['fields']['notificationTokenTemplates'] = [
+    'label'            => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'],
+    'exclude'          => true,
+    'inputType'        => 'multiColumnWizard',
+    'options_callback' => [FormFieldDcaListener::class, 'templateOptions'],
+    'eval'             => [
+        'tl_class'     => 'clr',
+        'columnFields' => [
+            'format'   => [
+                'label'     => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'],
+                'inputType' => 'text',
+                'eval'      => ['style' => 'width: 200px'],
+            ],
+            'template' => [
+                'label'            => &$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'],
+                'inputType'        => 'select',
+                'options_callback' => [FormFieldDcaListener::class, 'templateOptions'],
+                'eval'             => ['includeBlankOption' => true, 'chosen' => true, 'style' => 'width:400px'],
+            ],
+        ],
+    ],
+    'sql'              => "blob NULL",
 ];
 
 $fieldsetPalette = System::getContainer()->get('inspiredminds.fieldsetduplication.helper.field')->getFieldsetPalette();

--- a/src/Resources/contao/languages/de/tl_form_field.php
+++ b/src/Resources/contao/languages/de/tl_form_field.php
@@ -11,3 +11,6 @@ declare(strict_types=1);
  */
 
 $GLOBALS['TL_LANG']['tl_form_field']['allowDuplication'] = ['Duplizieren erlauben', 'Erlaubt die Duplizierung des Inhalts dieses Fieldsets im Frontend.'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'] = ['Notification Tokem Templates', 'Rendere Fieldset als Notification Token. Verfügbar unter <em>form_{name}_{format}.'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'] = ['Format', 'Bestimmen Sie den Namen des Formats'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'] = ['Template', 'Bitte wählen Sie ein angepasstes Template aus.'];

--- a/src/Resources/contao/languages/de/tl_form_field.php
+++ b/src/Resources/contao/languages/de/tl_form_field.php
@@ -12,5 +12,5 @@ declare(strict_types=1);
 
 $GLOBALS['TL_LANG']['tl_form_field']['allowDuplication'] = ['Duplizieren erlauben', 'Erlaubt die Duplizierung des Inhalts dieses Fieldsets im Frontend.'];
 $GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'] = ['Notification Tokem Templates', 'Rendere Fieldset als Notification Token. Verfügbar unter <em>form_{name}_{format}.'];
-$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'] = ['Format', 'Bestimmen Sie den Namen des Formats'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'] = ['Format', 'Bestimmen Sie den Namen des Formats.'];
 $GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'] = ['Template', 'Bitte wählen Sie ein angepasstes Template aus.'];

--- a/src/Resources/contao/languages/en/tl_form_field.php
+++ b/src/Resources/contao/languages/en/tl_form_field.php
@@ -11,3 +11,6 @@ declare(strict_types=1);
  */
 
 $GLOBALS['TL_LANG']['tl_form_field']['allowDuplication'] = ['Allow duplication', 'Allows the duplication of this fieldset in the front end.'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenTemplates'] = ['Notification token templates', 'Render fieldset as notification token by parsing a template. Accessible as <em>form_{name}_{format}.'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormat'] = ['Format', 'Define the required format.'];
+$GLOBALS['TL_LANG']['tl_form_field']['notificationTokenFormatTemplate'] = ['Template', 'Choose a custom template for the format.'];

--- a/src/Resources/contao/templates/nc_fieldset_duplication_html.html5
+++ b/src/Resources/contao/templates/nc_fieldset_duplication_html.html5
@@ -1,0 +1,20 @@
+<?php if ($this->values): ?>
+<table>
+    <thead>
+        <tr>
+            <?php foreach (array_keys($this->values[0]) as $name): ?>
+            <td><?= $this->labels[$name] ?? $name ?></td>
+            <?php endforeach ?>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($this->values as $row): ?>
+        <tr>
+            <?php foreach ($row as $value): ?>
+            <td><?= $value ?></td>
+            <?php endforeach ?>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif ?>

--- a/src/Resources/contao/templates/nc_fieldset_duplication_html.html5
+++ b/src/Resources/contao/templates/nc_fieldset_duplication_html.html5
@@ -1,20 +1,20 @@
 <?php if ($this->values): ?>
 <table>
-    <thead>
-        <tr>
-            <?php foreach (array_keys($this->values[0]) as $name): ?>
-            <td><?= $this->labels[$name] ?? $name ?></td>
-            <?php endforeach ?>
-        </tr>
-    </thead>
-    <tbody>
+  <thead>
+    <tr>
+      <?php foreach (array_keys($this->values[0]) as $name): ?>
+        <td><?= $this->labels[$name] ?? $name ?></td>
+      <?php endforeach ?>
+    </tr>
+  </thead>
+  <tbody>
     <?php foreach ($this->values as $row): ?>
-        <tr>
-            <?php foreach ($row as $value): ?>
-            <td><?= $value ?></td>
-            <?php endforeach ?>
-        </tr>
+      <tr>
+        <?php foreach ($row as $value): ?>
+          <td><?= $value ?></td>
+        <?php endforeach ?>
+      </tr>
     <?php endforeach; ?>
-    </tbody>
+  </tbody>
 </table>
 <?php endif ?>

--- a/src/Resources/contao/templates/nc_fieldset_duplication_json.html5
+++ b/src/Resources/contao/templates/nc_fieldset_duplication_json.html5
@@ -1,0 +1,1 @@
+<?= json_encode($this->values) ?>

--- a/src/Resources/contao/templates/nc_fieldset_duplication_text.html5
+++ b/src/Resources/contao/templates/nc_fieldset_duplication_text.html5
@@ -1,0 +1,7 @@
+<?php foreach ($this->values as $row): ?>
+<?php foreach ($row as $name => $value): ?>
+<?= $this->labels[$name] ?>: <?= $value ?>
+
+<?php endforeach ?>
+
+<?php endforeach; ?>


### PR DESCRIPTION
This pull request provides a feature that duplicated fieldsets are rendered as token for the notification center (also available without the nc).

If a fieldset is marked as duplication, the form field edit mask is extended

- Field name, required for the token name
- Notification token templates: Map between a custom format and a predefined template

This pull request provides three templates:

- `nc_fieldset_duplication_text`: Renders label: value pairs
- `nc_fieldset_duplication_html`: Renders an html table
- `nc_fieldset_duplication_json`: Output values as json array