### PR TITLE
Add support for terminal42/contao-mp_forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "require-dev": {
          "contao/manager-plugin": "^2.0",
          "friendsofphp/php-cs-fixer": "^3.0",
-         "terminal42/contao-leads": "^1.4"
+         "terminal42/contao-leads": "^1.4",
+        "terminal42/contao-mp_forms": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -133,9 +133,6 @@ class FormHookListener
                                     // set the name
                                     $clone->name = $duplicateName;
 
-                                    // set the label
-                                    $clone->label = $clone->label.' '.$duplicateNumber;
-
                                     // set the sorting
                                     $clone->sorting = ++$sorting;
 

--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -81,7 +81,7 @@ class FormHookListener
         }
 
         // check if form was submitted
-        if ($submittedData['FORM_SUBMIT'] === $formId) {
+        if (($submittedData['FORM_SUBMIT'] ?? null) === $formId) {
             $fieldsetGroups = $this->buildFieldsetGroups($fields);
 
             $processed = [];

--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -20,6 +20,7 @@ use Contao\FrontendTemplate;
 use Contao\StringUtil;
 use Contao\Widget;
 use InspiredMinds\ContaoFieldsetDuplication\Helper\FieldHelper;
+use MPFormsFormManager;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class FormHookListener
@@ -49,7 +50,7 @@ class FormHookListener
             if (!empty($widget->doNotCopyExistingValues)) {
                 $arrClasses[] = 'duplicate-fieldset-donotcopy';
             }
-            
+
             $widget->class = implode(' ', $arrClasses);
         }
 
@@ -58,18 +59,36 @@ class FormHookListener
 
     public function onCompileFormFields(array $fields, $formId, Form $objForm): array
     {
-        // get the current request
-        $request = $this->requestStack->getCurrentRequest();
+        static $alreadyProcessed = false;
+
+        // Ensure the listener is called only once (e.g. in combination with MPForms)
+        if ($alreadyProcessed) {
+            return $fields;
+        }
+
+        $alreadyProcessed = true;
+        $submittedData = [];
+
+        // Get the submitted data from the request
+        if (($request = $this->requestStack->getCurrentRequest()) !== null) {
+            $submittedData = $request->request->all();
+        }
+
+        // Get the submitted data from MPForms
+        if (count($submittedData) === 0 && class_exists(\MPFormsFormManager::class)) {
+            $manager = new MPFormsFormManager($objForm->id);
+            $submittedData = $manager->getDataOfStep($manager->getCurrentStep())['originalPostData'] ?? [];
+        }
 
         // check if form was submitted
-        if ($request->request->get('FORM_SUBMIT') === $formId) {
+        if ($submittedData['FORM_SUBMIT'] === $formId) {
             $fieldsetGroups = $this->buildFieldsetGroups($fields);
 
             $processed = [];
             $fieldsetDuplicates = [];
 
             // search for duplicates
-            foreach (array_keys($request->request->all()) as $duplicateName) {
+            foreach (array_keys($submittedData) as $duplicateName) {
                 // check if already processed
                 if (\in_array($duplicateName, $processed, true)) {
                     continue;


### PR DESCRIPTION
This pull request adds support for terminal42/contao-mp_forms.

One thing to note is that I have removed the label increasing count. For example, if you add 3 items and go back to this view (whether it is MP Forms page switch or a form validation error), then the fieldsets and labels look like this:

1. Person: Name, E-mail.
2. Person 1: Name 1, E-mail 1.
3. Person 2: Name 2, E-mail 2.

What's the problem? When you duplicate a fieldset via JS now, it will not update the legend and labels, resulting in:

1. Person: Name, E-mail.
2. Person 1: Name 1, E-mail 1.
3. Person 1: Name 1, E-mail 1.
4. Person 2: Name 2, E-mail 2.

Or

1. Person: Name, E-mail.
2. Person 1: Name 1, E-mail 1.
3. Person 2: Name 2, E-mail 2.
4. Person 2: Name 2, E-mail 2.

All depending which fieldset you duplicate. I tried to change this behavior in JS, but that would require "reindexing" all fieldsets. To do that I'd rewrite whole JS code probably, which I didn't want to do just yet. 

Thus, I decided to remove the increasing labels. They were a bit inconsistent anyway, because when you duplicate fieldsets via JS the legends/labels did not change. However if you revisit the page, then the labels suddenly change to what's listed above.

I am looking forward to your feedback!