### PR TITLE
Compatibility issues with MP_Forms and Notification Center

### DIFF
--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -21,6 +21,7 @@ use Contao\StringUtil;
 use Contao\Widget;
 use InspiredMinds\ContaoFieldsetDuplication\Helper\FieldHelper;
 use MPFormsFormManager;
+use MPFormsSessionManager;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class FormHookListener
@@ -59,14 +60,13 @@ class FormHookListener
 
     public function onCompileFormFields(array $fields, $formId, Form $objForm): array
     {
-        static $alreadyProcessed = false;
-
-        // Ensure the listener is called only once (e.g. in combination with MPForms)
-        if ($alreadyProcessed) {
-            return $fields;
+        // Return if the fields were already cloned by this listener (e.g. in combination with MPForms)
+        foreach ($fields as $field) {
+            if (false !== (strpos($field->name, '_duplicate_'))) {
+                return $fields;
+            }
         }
 
-        $alreadyProcessed = true;
         $submittedData = [];
 
         // Get the submitted data from the request
@@ -75,8 +75,8 @@ class FormHookListener
         }
 
         // Get the submitted data from MPForms
-        if (count($submittedData) === 0 && class_exists(\MPFormsFormManager::class)) {
-            $manager = new MPFormsFormManager($objForm->id);
+        if (count($submittedData) === 0 && class_exists(\MPFormsSessionManager::class)) {
+            $manager = new MPFormsSessionManager($objForm->id);
             $submittedData = $manager->getDataOfStep($manager->getCurrentStep())['originalPostData'] ?? [];
         }
 

--- a/src/EventListener/FormHookListener.php
+++ b/src/EventListener/FormHookListener.php
@@ -82,109 +82,7 @@ class FormHookListener
 
         // check if form was submitted
         if (($submittedData['FORM_SUBMIT'] ?? null) === $formId) {
-            $fieldsetGroups = $this->buildFieldsetGroups($fields);
-
-            $processed = [];
-            $fieldsetDuplicates = [];
-
-            // search for duplicates
-            foreach (array_keys($submittedData) as $duplicateName) {
-                // check if already processed
-                if (\in_array($duplicateName, $processed, true)) {
-                    continue;
-                }
-
-                // check if it is a duplicate
-                if (false !== ($intPos = strpos($duplicateName, '_duplicate_'))) {
-                    // get the non duplicate name
-                    $originalName = substr($duplicateName, 0, $intPos);
-
-                    // get the duplicate number
-                    $duplicateNumber = (int) (substr($duplicateName, -1));
-
-                    // clone the fieldset
-                    foreach ($fieldsetGroups as $fieldsetGroup) {
-                        foreach ($fieldsetGroup as $field) {
-                            if ($field->name === $originalName) {
-                                // new sorting base number
-                                $sorting = $fieldsetGroup[\count($fieldsetGroup) - 1]->sorting;
-
-                                $duplicatedFields = [];
-
-                                foreach ($fieldsetGroup as $field) {
-                                    // set the actual duplicate name
-                                    $duplicateName = $field->name.'_duplicate_'.$duplicateNumber;
-
-                                    // clone the field
-                                    $clone = clone $field;
-
-                                    // remove allow duplication class
-                                    if ($this->fieldHelper->isFieldsetStart($clone)) {
-                                        $clone->class = implode(' ', array_diff(explode(' ', $clone->class), ['allow-duplication']));
-                                        $clone->class .= ($clone->class ? ' ' : '').'duplicate-fieldset-'.$field->id.' duplicate';
-                                    }
-
-                                    // set the id
-                                    $clone->id = $field->id.'_duplicate_'.$duplicateNumber;
-
-                                    // set the original id
-                                    $clone->originalId = $field->id;
-
-                                    // set the name
-                                    $clone->name = $duplicateName;
-
-                                    // set the sorting
-                                    $clone->sorting = ++$sorting;
-
-                                    // add the clone
-                                    $duplicatedFields[] = $clone;
-
-                                    // add to processed
-                                    $processed[] = $duplicateName;
-                                }
-
-                                $fieldsetDuplicates[] = $duplicatedFields;
-
-                                break 2;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // reverse the fieldset duplicates
-            $fieldsetDuplicates = array_reverse($fieldsetDuplicates);
-
-            // process $fields
-            $fields = array_values($fields);
-
-            // go through the duplicated fieldsets
-            foreach ($fieldsetDuplicates as $duplicatedFieldset) {
-                // search for the stop field
-                $stopId = null;
-                foreach ($duplicatedFieldset as $duplicatedField) {
-                    if ($this->fieldHelper->isFieldsetStop($duplicatedField)) {
-                        $stopId = $duplicatedField->originalId;
-                        break;
-                    }
-                }
-
-                // search for the index position of the original stop field
-                if (null !== $stopId) {
-                    $stopIdx = null;
-                    for ($i = 0; $i < \count($fields); ++$i) {
-                        if ($fields[$i]->id === $stopId) {
-                            $stopIdx = $i;
-                            break;
-                        }
-                    }
-
-                    // insert fields after original stop field
-                    if (null !== $stopIdx) {
-                        array_splice($fields, $stopIdx + 1, 0, $duplicatedFieldset);
-                    }
-                }
-            }
+            $fields = $this->cloneFields($fields, $submittedData);
         }
 
         // return the fields
@@ -214,6 +112,15 @@ class FormHookListener
 
     public function onPrepareFormData(array &$submittedData, array $labels, array $fields, Form $form): void
     {
+        if (class_exists(\MPFormsFormManager::class)) {
+            $manager = new MPFormsFormManager($form->id);
+
+            if ($manager->getNumberOfSteps() > 1) {
+                $fields = $manager->getFieldsWithoutPageBreaks();
+                $fields = $this->cloneFields($fields, $submittedData);
+            }
+        }
+
         $fieldsetGroups = $this->buildFieldsetGroups($fields);
         $values = $this->groupFieldsetValues($fieldsetGroups, $submittedData);
 
@@ -247,6 +154,116 @@ class FormHookListener
         }
 
         Config::set('debugMode', $debugMode);
+    }
+
+    private function cloneFields(array $fields, array $submittedData): array
+    {
+        $fieldsetGroups = $this->buildFieldsetGroups($fields);
+
+        $processed = [];
+        $fieldsetDuplicates = [];
+
+        // search for duplicates
+        foreach (array_keys($submittedData) as $duplicateName) {
+            // check if already processed
+            if (\in_array($duplicateName, $processed, true)) {
+                continue;
+            }
+
+            // check if it is a duplicate
+            if (false !== ($intPos = strpos($duplicateName, '_duplicate_'))) {
+                // get the non duplicate name
+                $originalName = substr($duplicateName, 0, $intPos);
+
+                // get the duplicate number
+                $duplicateNumber = (int) (substr($duplicateName, -1));
+
+                // clone the fieldset
+                foreach ($fieldsetGroups as $fieldsetGroup) {
+                    foreach ($fieldsetGroup as $field) {
+                        if ($field->name === $originalName) {
+                            // new sorting base number
+                            $sorting = $fieldsetGroup[\count($fieldsetGroup) - 1]->sorting;
+
+                            $duplicatedFields = [];
+
+                            foreach ($fieldsetGroup as $field) {
+                                // set the actual duplicate name
+                                $duplicateName = $field->name.'_duplicate_'.$duplicateNumber;
+
+                                // clone the field
+                                $clone = clone $field;
+
+                                // remove allow duplication class
+                                if ($this->fieldHelper->isFieldsetStart($clone)) {
+                                    $clone->class = implode(' ', array_diff(explode(' ', $clone->class), ['allow-duplication']));
+                                    $clone->class .= ($clone->class ? ' ' : '').'duplicate-fieldset-'.$field->id.' duplicate';
+                                }
+
+                                // set the id
+                                $clone->id = $field->id.'_duplicate_'.$duplicateNumber;
+
+                                // set the original id
+                                $clone->originalId = $field->id;
+
+                                // set the name
+                                $clone->name = $duplicateName;
+
+                                // set the sorting
+                                $clone->sorting = ++$sorting;
+
+                                // add the clone
+                                $duplicatedFields[] = $clone;
+
+                                // add to processed
+                                $processed[] = $duplicateName;
+                            }
+
+                            $fieldsetDuplicates[] = $duplicatedFields;
+
+                            break 2;
+                        }
+                    }
+                }
+            }
+        }
+
+        // reverse the fieldset duplicates
+        $fieldsetDuplicates = array_reverse($fieldsetDuplicates);
+
+        // process $fields
+        $fields = array_values($fields);
+
+        // go through the duplicated fieldsets
+        foreach ($fieldsetDuplicates as $duplicatedFieldset) {
+            // search for the stop field
+            $stopId = null;
+            foreach ($duplicatedFieldset as $duplicatedField) {
+                if ($this->fieldHelper->isFieldsetStop($duplicatedField)) {
+                    $stopId = $duplicatedField->originalId;
+                    break;
+                }
+            }
+
+            // search for the index position of the original stop field
+            if (null !== $stopId) {
+                $stopIdx = null;
+                for ($i = 0; $i < \count($fields); ++$i) {
+                    if ($fields[$i]->id === $stopId) {
+                        $stopIdx = $i;
+                        break;
+                    }
+                }
+
+                // insert fields after original stop field
+                if (null !== $stopIdx) {
+                    array_splice($fields, $stopIdx + 1, 0, $duplicatedFieldset);
+                }
+            }
+        }
+
+        // return the fields
+        return $fields;
     }
 
     /**

--- a/src/Resources/public/jquery.fieldset.duplication.js
+++ b/src/Resources/public/jquery.fieldset.duplication.js
@@ -19,7 +19,7 @@
             var maxRows = null;
             var duplicateIndex = 0;
             var options = $.extend({}, defaults, settings, $original.data('fieldset-duplication-config') || {})
-            
+
             // determine the fieldset group selector
             var classList = $original.attr('class').split(/\s+/);
             $.each(classList, function(index, item)

--- a/src/Resources/public/jquery.fieldset.duplication.js
+++ b/src/Resources/public/jquery.fieldset.duplication.js
@@ -19,7 +19,7 @@
             var maxRows = null;
             var duplicateIndex = 0;
             var options = $.extend({}, defaults, settings, $original.data('fieldset-duplication-config') || {})
-
+            
             // determine the fieldset group selector
             var classList = $original.attr('class').split(/\s+/);
             $.each(classList, function(index, item)
@@ -39,7 +39,17 @@
                     return false;
                 }
             });
-
+            // determine the highest existing duplicate number 
+            $(selector).each(function()
+            {
+                $(this).find('input[name], select[name], textarea[name]').each(function() {
+                    var match = $(this).attr('id').match(/_duplicate_(\d+)/);
+                    if (match && match[1] > duplicateIndex) {
+                        duplicateIndex = match[1];
+                    }
+                });
+            });
+            
             var updateFieldsets = function()
             {
                 $fieldsets = $(selector);


### PR DESCRIPTION
While using this bundle in combination with MP_Forms and the Notification Center, I noticed some issues:

1. The `duplicateIndex` in https://github.com/inspiredminds/contao-fieldset-duplication/blob/acba635501817687b38fa79290c2144eba82576d/src/Resources/public/jquery.fieldset.duplication.js#L20 is initialized to zero when the page is loaded. When you create a duplicate, the input field gets a name like `test_duplicate_1`. When you reload the page or a form validation error occurs, the next duplicated input field gets the same name `test_duplicate_1` and overwrites the POST value. I fixed this by searching for the highest duplicate number in 6332d582a7dbf0cc1137f1c60c0441584971ec33.
2. The `prepareFormData` hook receives only fields for the current step, while it requires all fields for the notification tokens. I fixed this by using the `getFieldsWithoutPageBreaks` method and running the cloning logic again in e81e724b4de88f42a7832e090c947576b2eec992.
3. When using the `MPFormsStepsModule` the fieldsets were not duplicated when reloading the page. The `compileFormFields` hook is called multiple times because of the `MPFormsFormManager` and sometimes the cloned fields were reset. I made sure that in this case the cloning logic in the `onCompileFormFields` method is run again. I also used the `MPFormsSessionManager` in order to not create a recursion. 2d0a0b82e4aca8cbfa607d308a6b2fe814748948

However, I am not sure if these are the best solutions.

/cc @qzminski 