### PR TITLE
Add leads 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /vendor
 /composer.lock
+.idea

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "composer/semver": "^1.0 || ^2.0 || ^3.0",
         "doctrine/dbal": "^2.11 || ^3.0",
         "jean85/pretty-package-versions": "^1.0 || ^2.0",
-        "mvo/contao-group-widget": "^1.3"
+        "mvo/contao-group-widget": "^1.3",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
          "contao/manager-plugin": "^2.0",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -17,6 +17,7 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use InspiredMinds\ContaoFieldsetDuplication\ContaoFieldsetDuplication;
+use Terminal42\LeadsBundle\Terminal42LeadsBundle;
 
 /**
  * Plugin for the Contao Manager.
@@ -28,9 +29,15 @@ class Plugin implements BundlePluginInterface
      */
     public function getBundles(ParserInterface $parser)
     {
+        $loadAfter = [ContaoCoreBundle::class, 'conditionalformfields', 'leads'];
+
+        if (class_exists(Terminal42LeadsBundle::class)) {
+            $loadAfter[] = Terminal42LeadsBundle::class;
+        }
+
         return [
             BundleConfig::create(ContaoFieldsetDuplication::class)
-                ->setLoadAfter([ContaoCoreBundle::class, 'conditionalformfields', 'leads']),
+                ->setLoadAfter($loadAfter),
         ];
     }
 }

--- a/src/EventListener/LeadsListener.php
+++ b/src/EventListener/LeadsListener.php
@@ -12,20 +12,26 @@ declare(strict_types=1);
 
 namespace InspiredMinds\ContaoFieldsetDuplication\EventListener;
 
+use Codefog\HasteBundle\Formatter;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Doctrine\DBAL\Connection;
 use Haste\Util\Format;
 use InspiredMinds\ContaoFieldsetDuplication\Helper\FieldHelper;
+use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Terminal42\LeadsBundle\Terminal42LeadsBundle;
 
-class LeadsListener
+class LeadsListener implements ServiceSubscriberInterface
 {
-    private Connection $connection;
-    private FieldHelper $fieldHelper;
+    private Connection         $connection;
+    private FieldHelper        $fieldHelper;
+    private ContainerInterface $container;
 
-    public function __construct(Connection $connection, FieldHelper $fieldHelper)
+    public function __construct(ContainerInterface $container, Connection $connection, FieldHelper $fieldHelper)
     {
         $this->connection = $connection;
         $this->fieldHelper = $fieldHelper;
+        $this->container = $container;
     }
 
     /**
@@ -41,71 +47,34 @@ class LeadsListener
     }
 
     /**
+     * @Hook("processFormData")
+     */
+    public function onProcessFormData(array $postData, array $formConfig, $files): void
+    {
+        if (!class_exists(Terminal42LeadsBundle::class) || !$formConfig['leadEnabled']) {
+            return;
+        }
+
+        $result = $this->connection->createQueryBuilder()->select('id')->from('tl_lead')
+            ->where('form_id=:form_id')
+            ->andWhere('tstamp>:tstamp')
+            ->andWhere('post_data=:post_data')
+            ->setParameter('form_id', $formConfig['id'])
+            ->setParameter('tstamp', time() - 60)
+            ->setParameter('post_data', serialize($postData))
+            ->executeQuery()->fetchOne();
+
+        if (false !== $result) {
+            $this->storeDublicateFields($formConfig, $postData, $result, 3);
+        }
+    }
+
+    /**
      * @Hook("storeLeadsData")
      */
     public function onStoreLeadsData(array $arrPost, array $form, array $arrFiles = null, int $intLead): void
     {
-        // Fetch master form fields
-        if ($form['leadMaster'] > 0) {
-            $leadFields = $this->connection->fetchAllAssociative(
-                "SELECT f2.*, f1.id AS master_id, f1.name AS postName FROM tl_form_field f1 LEFT JOIN tl_form_field f2 ON f1.leadStore=f2.id WHERE f1.pid=? AND f1.leadStore>0 AND (f2.leadStore=? OR f2.type=? OR f2.type=?) AND f1.invisible=? ORDER BY f2.sorting",
-                [$form['id'], 1, 'fieldsetStart', 'fieldsetStop', '']
-            );
-        } else {
-            $leadFields = $this->connection->fetchAllAssociative(
-                "SELECT *, id AS master_id, name AS postName FROM tl_form_field WHERE pid=? AND (leadStore=? OR type=? OR type=?) AND invisible=? ORDER BY sorting",
-                [$form['id'], 1, 'fieldsetStart', 'fieldsetStop', '']
-            );
-        }
-
-
-        $time = time();
-
-        foreach ($this->getDuplicateFields($leadFields) as $fieldset) {
-            $fieldsetFields = [];
-
-            // Collect the fields
-            foreach ($fieldset['fields'] as $field) {
-                foreach ($arrPost as $name => $value) {
-                    if (preg_match('/^('.preg_quote($field['name']).')(_duplicate_(\d+))?$/', $name, $matches)) {
-                        $index = (int) ($matches[3] ?? 0) + 1;
-                        $fieldsetFields[$index][$field['name']] = [
-                            'label' => Format::dcaLabelFromArray($field),
-                            'value' => Format::dcaValueFromArray($field, $value),
-                            'raw' => $value,
-                        ];
-                    }
-                }
-            }
-
-            $label = [];
-
-            // Generate the label
-            foreach ($fieldsetFields as $index => $fields) {
-                foreach ($fields as $value) {
-                    $label[] = sprintf('%d. %s: %s', $index, $value['label'], $value['value']);
-                }
-            }
-
-            if (\count($fieldsetFields) > 0) {
-                $this->connection->insert('tl_lead_data', [
-                    'pid' => $intLead,
-                    'sorting' => $fieldset['fieldset']['sorting'],
-                    'tstamp' => $time,
-                    'master_id' => $fieldset['fieldset']['master_id'],
-                    'field_id' => $fieldset['fieldset']['id'],
-                    'name' => $fieldset['fieldset']['name'],
-                    'value' => serialize($label),
-                    'label' => implode("\n", $label),
-                    'fieldset_data' => serialize($fieldsetFields),
-                ]);
-            }
-
-            // Remove the original fields that were duplicated
-            foreach ($fieldset['fields'] as $field) {
-                $this->connection->delete('tl_lead_data', ['pid' => $intLead, 'name' => $field['name']]);
-            }
-        }
+        $this->storeDublicateFields($form, $arrPost, $intLead);
     }
 
     public function getDuplicateFields(array $allFields): array
@@ -140,5 +109,96 @@ class LeadsListener
         }
 
         return $duplicateFields;
+    }
+
+    public static function getSubscribedServices()
+    {
+        return [
+            '?'.Formatter::class,
+        ];
+    }
+
+    private function storeDublicateFields(array $form, array $postData, int $leadId, int $leadsVersion = 1)
+    {
+        $mainIdFieldName = 'master_id';
+        $mainFieldName = 'leadMaster';
+
+        if ($leadsVersion === 3) {
+            $mainIdFieldName = 'main_id';
+            $mainFieldName = 'leadMain';
+        }
+
+        // Fetch master form fields
+        if ($form[$mainFieldName] > 0) {
+            $leadFields = $this->connection->fetchAllAssociative(
+                "SELECT f2.*, f1.id AS ".$mainIdFieldName.", f1.name AS postName FROM tl_form_field f1 LEFT JOIN tl_form_field f2 ON f1.leadStore=f2.id WHERE f1.pid=? AND f1.leadStore>0 AND (f2.leadStore=? OR f2.type=? OR f2.type=?) AND f1.invisible=? ORDER BY f2.sorting",
+                [$form['id'], 1, 'fieldsetStart', 'fieldsetStop', '']
+            );
+        } else {
+            $leadFields = $this->connection->fetchAllAssociative(
+                "SELECT *, id AS ".$mainIdFieldName.", name AS postName FROM tl_form_field WHERE pid=? AND (leadStore=? OR type=? OR type=?) AND invisible=? ORDER BY sorting",
+                [$form['id'], 1, 'fieldsetStart', 'fieldsetStop', '']
+            );
+        }
+
+
+        $time = time();
+
+        foreach ($this->getDuplicateFields($leadFields) as $fieldset) {
+            $fieldsetFields = [];
+
+            // Collect the fields
+            foreach ($fieldset['fields'] as $field) {
+                foreach ($postData as $name => $value) {
+                    if (preg_match('/^(' . preg_quote($field['name']) . ')(_duplicate_(\d+))?$/', $name, $matches)) {
+                        $index = (int)($matches[3] ?? 0) + 1;
+                        if (class_exists(Formatter::class) && $this->container->has(Formatter::class)) {
+                            $fieldLabel = $this->container->get(Formatter::class)->dcaLabelFromArray($field);
+                            $fieldValue = $this->container->get(Formatter::class)->dcaValueFromArray($field, $value);
+                        } elseif (class_exists(Format::class)) {
+                            $fieldLabel = Format::dcaLabelFromArray($field);
+                            $fieldValue = Format::dcaValueFromArray($field, $value);
+                        } else {
+                            continue;
+                        }
+
+                        $fieldsetFields[$index][$field['name']] = [
+                            'label' => $fieldLabel,
+                            'value' => $fieldValue,
+                            'raw'   => $value,
+                        ];
+                    }
+                }
+            }
+
+            $label = [];
+
+            // Generate the label
+            foreach ($fieldsetFields as $index => $fields) {
+                foreach ($fields as $value) {
+                    $label[] = sprintf('%d. %s: %s', $index, $value['label'], $value['value']);
+                }
+            }
+
+            if (\count($fieldsetFields) > 0) {
+                $this->connection->insert('tl_lead_data', [
+                    'pid'           => $leadId,
+                    'sorting'       => $fieldset['fieldset']['sorting'],
+                    'tstamp'        => $time,
+                    $mainIdFieldName       => $fieldset['fieldset'][$mainIdFieldName],
+                    'field_id'      => $fieldset['fieldset']['id'],
+                    'name'          => $fieldset['fieldset']['name'],
+                    'value'         => serialize($label),
+                    'label'         => implode("\n", $label),
+                    'fieldset_data' => serialize($fieldsetFields),
+                ]);
+            }
+
+            // Remove the original fields that were duplicated
+            foreach ($fieldset['fields'] as $field) {
+                $this->connection->delete('tl_lead_data', ['pid' => $leadId, 'name' => $field['name']]);
+            }
+        }
+        return $matches;
     }
 }

--- a/src/EventListener/LeadsListener.php
+++ b/src/EventListener/LeadsListener.php
@@ -77,47 +77,6 @@ class LeadsListener implements ServiceSubscriberInterface
         $this->storeDublicateFields($form, $arrPost, $intLead);
     }
 
-    public function getDuplicateFields(array $allFields): array
-    {
-        static $duplicateFields = null;
-
-        if (!\is_array($duplicateFields)) {
-            $duplicateFields = [];
-            $fieldsetGroup = null;
-
-            foreach ($allFields as $field) {
-                if ($this->fieldHelper->isFieldsetStart((object) $field) && $field['allowDuplication'] && $field['leadStore']) {
-                    $fieldsetGroup = $field['name'];
-
-                    $duplicateFields[$fieldsetGroup] = [
-                        'fieldset' => $field,
-                        'fields' => [],
-                    ];
-
-                    continue;
-                }
-
-                if ($this->fieldHelper->isFieldsetStop((object) $field)) {
-                    $fieldsetGroup = null;
-                    continue;
-                }
-
-                if (null !== $fieldsetGroup) {
-                    $duplicateFields[$fieldsetGroup]['fields'][] = $field;
-                }
-            }
-        }
-
-        return $duplicateFields;
-    }
-
-    public static function getSubscribedServices()
-    {
-        return [
-            '?'.Formatter::class,
-        ];
-    }
-
     private function storeDublicateFields(array $form, array $postData, int $leadId, int $leadsVersion = 1)
     {
         $mainIdFieldName = 'master_id';
@@ -200,5 +159,44 @@ class LeadsListener implements ServiceSubscriberInterface
             }
         }
         return $matches;
+    }
+
+    public function getDuplicateFields(array $allFields): void
+    {
+        static $duplicateFields = null;
+
+        if (!\is_array($duplicateFields)) {
+            $duplicateFields = [];
+            $fieldsetGroup = null;
+
+            foreach ($allFields as $field) {
+                if ($this->fieldHelper->isFieldsetStart((object) $field) && $field['allowDuplication'] && $field['leadStore']) {
+                    $fieldsetGroup = $field['name'];
+
+                    $duplicateFields[$fieldsetGroup] = [
+                        'fieldset' => $field,
+                        'fields' => [],
+                    ];
+
+                    continue;
+                }
+
+                if ($this->fieldHelper->isFieldsetStop((object) $field)) {
+                    $fieldsetGroup = null;
+                    continue;
+                }
+
+                if (null !== $fieldsetGroup) {
+                    $duplicateFields[$fieldsetGroup]['fields'][] = $field;
+                }
+            }
+        }
+    }
+
+    public static function getSubscribedServices()
+    {
+        return [
+            '?'.Formatter::class,
+        ];
     }
 }

--- a/src/EventListener/LeadsListener.php
+++ b/src/EventListener/LeadsListener.php
@@ -195,8 +195,12 @@ class LeadsListener implements ServiceSubscriberInterface
 
     public static function getSubscribedServices()
     {
-        return [
-            '?'.Formatter::class,
-        ];
+        $services = [];
+
+        if (class_exists(Formatter::class)) {
+            $services[Formatter::class] = '?'.Formatter::class;
+        }
+
+        return $services;
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,9 +19,9 @@ services:
       - '@inspiredminds.fieldsetduplication.helper.field'
 
   InspiredMinds\ContaoFieldsetDuplication\EventListener\LeadsListener:
-    arguments:
-      - '@database_connection'
-      - '@inspiredminds.fieldsetduplication.helper.field'
+    autowire: true
+    bind:
+      $fieldHelper: '@inspiredminds.fieldsetduplication.helper.field'
 
   inspiredminds.fieldsetduplication.helper.field:
     class: InspiredMinds\ContaoFieldsetDuplication\Helper\FieldHelper


### PR DESCRIPTION
This PR adds support for leads 3.

Since Leads 3 do not offer the storeLeadsData hook, I needed to use the processFormData hook, where I load the corresponding leads data set. I also needed to adjust some code to make it compatible with haste 5 and changed database field names. The code should be compatible with haste 4+5 and lead 1+3.